### PR TITLE
fix remix next release 2.9.0 single fetch data cache issue

### DIFF
--- a/playgrounds/remix-hono/server/middlewares.ts
+++ b/playgrounds/remix-hono/server/middlewares.ts
@@ -105,7 +105,7 @@ export function refreshSession() {
  */
 export function cache(seconds: number) {
 	return createMiddleware(async (c, next) => {
-		if (!c.req.path.match(/\.[a-zA-Z0-9]+$/)) {
+		if (!c.req.path.match(/\.[a-zA-Z0-9]+$/) || c.req.path.endsWith(".data")) {
 			return next();
 		}
 


### PR DESCRIPTION
remix single fetch no longer uses ?data to obtain data, but uses the .data suffix, which needs to be excluded from the cache